### PR TITLE
[MIIO] Use THING_TYPE_VACUUM for discovered vacuums

### DIFF
--- a/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
+++ b/bundles/org.openhab.binding.miio/src/main/java/org/openhab/binding/miio/internal/discovery/MiIoDiscovery.java
@@ -247,6 +247,8 @@ public class MiIoDiscovery extends AbstractDiscoveryService {
         ThingTypeUID thingType = MiIoDevices.getType(model).getThingType();
         if (id.startsWith("lumi.") || THING_TYPE_GATEWAY.equals(thingType) || THING_TYPE_LUMI.equals(thingType)) {
             uid = new ThingUID(thingType, Utils.getHexId(id).replace(".", "_"));
+        } else if {THING_TYPE_VACUUM.equals(thingType)) {
+            uid = new ThingUID(thingType, Utils.getHexId(id).replace(".", "_"));
         } else {
             uid = new ThingUID(THING_TYPE_MIIO, Utils.getHexId(id).replace(".", "_"));
         }


### PR DESCRIPTION
This little correction should change the thing type for discovered vacuums from miiio:basic to miio:vacuum.

I'm using the jenkins build to verify, so please don't merge yet. Thanks.